### PR TITLE
fix: tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,3 @@
-// {
-//   "extends": "@tsconfig/node16/tsconfig.json",
-//   "compilerOptions": {
-//     "allowSyntheticDefaultImports": true,
-//     "allowJs": true,
-//     "checkJs": true,
-//     "newLine": "lf",
-//     "declaration": true,
-//     "noImplicitAny": false,
-//     "moduleResolution": "node",
-//     "sourceMap": true,
-//     "outDir": "lib"
-//   },
-//   "include": ["src"],
-//   "exclude": ["node_modules", "**/*.spec.ts"]
-// }
 {
   "compilerOptions": {
     "allowUnreachableCode": false,
@@ -33,5 +17,5 @@
     "skipLibCheck": true
   },
   "include": ["./src"],
-  "exclude": ["./lib", "./node_modules"]
+  "exclude": ["./lib", "./node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
src의 jest 파일에서 root directory의 test 파일을 참조하는 경우가 있어, 
build 시 `./lib`아래 src와 test 디렉토리가 생기는 이슈가 있었습니다.
<img width="85" alt="Screen Shot 2022-05-27 at 18 06 36" src="https://user-images.githubusercontent.com/47456161/170668602-fee0edfb-a0c4-4481-87d4-c0d5c9084fe1.png">

exclude에 `*.spec.ts` 를 추가합니다.

**이슈 내용**
이전에도 겪었던 문제인데, 컴파일 target 코드에 target 밖 디렉토리의 소스코드를 참조하는 부분이 있으면 build가 예상과 다르게 되는 이슈입니다.

## 무엇을 어떻게 변경했나요?
1. tsconfig의 exclude 옵션에 ` "**/*.spec.ts"` 를 추가합니다.
2. ~~compile target을 es2021로 수정합니다~~

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?
npm run build

