### PR TITLE
update때는 테이블 전체 interface가 필요하지 않으므로 Partial을 이용하자

### DIFF
--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -61,9 +61,9 @@ export interface InsertOperations<ROW extends RowType> {
 }
 
 export interface UpdateOperations<ID extends IdType, ROW extends RowType> {
-  updateById(id: ID, data: ROW): Promise<number>;
+  updateById(id: ID, data: Partial<ROW>): Promise<number>;
 
-  update(filter: CrudFilter<ID, ROW>, data: ROW): Promise<number>;
+  update(filter: CrudFilter<ID, ROW>, data: Partial<ROW>): Promise<number>;
 }
 
 export interface DeleteOperations<ID extends IdType, ROW extends RowType> {
@@ -185,11 +185,11 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   //---------------------------------------------------------
   // UpdateOperation
 
-  async updateById(id: ID, data: ROW): Promise<number> {
+  async updateById(id: ID, data: Partial<ROW>): Promise<number> {
     return this.knex(this.table).where(this.idColumn, id).update(data);
   }
 
-  async update(filter: CrudFilter<ID, ROW>, data: ROW): Promise<number> {
+  async update(filter: CrudFilter<ID, ROW>, data: Partial<ROW>): Promise<number> {
     return this.knex(this.table)
       .modify((queryBuilder) => {
         this.applyFilter(queryBuilder, filter);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "target": "es2017",
+    "target": "es2021",
     "skipLibCheck": true
   },
   "include": ["./src"],


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
Update는 일부 컬럼에 대한 변경이므로 테이블 타입 전체가 필요하지 않다
fastdao는 백엔드 전용이므로 target이 es2021이어야 한다.

## 무엇을 어떻게 변경했나요?
update()와 updateById()의 data 인자 타입을 ROW에서 Partial<ROW>로 변경
tsconfig의 target을 es2021로 변경

## 어떻게 테스트 하셨나요?
npm run test
