### PR TITLE
상속 클래스를 위해서는 생성자가 protected여야 한다

### DIFF
--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -98,7 +98,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   private readonly updatedAtColumn: string;
   private readonly weaver?: Weaver<ID, ROW>;
 
-  private constructor(opts: CrudOperationsOpts<ID, ROW>) {
+  protected constructor(opts: CrudOperationsOpts<ID, ROW>) {
     // main connection for read/write
     this.knex = opts.knex;
     // separated connection for read-only

--- a/src/extra-operations.ts
+++ b/src/extra-operations.ts
@@ -38,7 +38,7 @@ export class ExtraOperations<ID extends IdType = number> {
   private readonly nameColumn: string;
   private readonly valueColumn: string;
 
-  private constructor(opts: ExtraOperationsOpts) {
+  protected constructor(opts: ExtraOperationsOpts) {
     this.knex = opts.knex;
     this.knexReplica = opts.knexReplica || opts.knex;
     this.table = opts.table;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
CrudOperations와 ExtraOperations의 생성자가 private이라서
이를 상속받은 클래스에서는 생성자를 호출할 수 없다.

## 무엇을 어떻게 변경했나요?
CrudOperations와 ExtraOperations의 생성자를 private에서 protected 변경

## 어떻게 테스트 하셨나요?
npm run test
