### PR TITLE
connect()의 result type인 Knex를 export하자

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,4 @@
 import knex, { Knex } from 'knex';
-export { Knex } from 'knex';
 import { toCamelCaseKeys, toSnakeCase } from '@day1co/fastcase';
 
 // REPLACE INTO table(col1,col2,...) VALUES(val1,val2,...)
@@ -32,3 +31,5 @@ export const connect = (config: Knex.Config): Knex => {
   process.on('exit', () => knexInstance.destroy());
   return knexInstance;
 };
+
+export { Knex } from 'knex';

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,5 @@
 import knex, { Knex } from 'knex';
+export { Knex } from 'knex';
 import { toCamelCaseKeys, toSnakeCase } from '@day1co/fastcase';
 
 // REPLACE INTO table(col1,col2,...) VALUES(val1,val2,...)

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -32,4 +32,4 @@ export const connect = (config: Knex.Config): Knex => {
   return knexInstance;
 };
 
-export { Knex } from 'knex';
+export type { Knex } from 'knex';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { connect } from './connection';
+export type { Knex } from './connection';
 export type { IdType, RowType } from './crud.type';
 export { CrudOperations } from './crud-operations';
 export type { CrudFilter, CrudFilterColumns, CrudOperationsOpts, StrictTypedCrudFilter } from './crud-operations';


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
fastdao를 import해서 쓰는 TypeScript 코드에서 connect() 함수를 사용하는 경우
result type인 Knex가 간접 dependency 문제로 인해 컴파일 에러가 남

## 무엇을 어떻게 변경했나요?
export { Knex } from 'knex'; 추가

## 어떻게 테스트 하셨나요?
npm run test
