### PR TITLE
RowType 대신 ROW로 제한할 수 있는 곳들 수정

### DIFF
--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -107,11 +107,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   //---------------------------------------------------------
   // SelectOperation
 
-  async select(
-    filter?: CrudFilter<ID, RowType>,
-    sorts?: Array<Sort>,
-    relations?: Array<Relation>
-  ): Promise<Array<ROW>> {
+  async select(filter?: CrudFilter<ID, ROW>, sorts?: Array<Sort>, relations?: Array<Relation>): Promise<Array<ROW>> {
     const query = this.knexReplica(this.table).modify((queryBuilder) => {
       this.applyFilter(queryBuilder, filter);
       this.applySort(queryBuilder, sorts);
@@ -140,7 +136,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   }
 
   async selectFirst(
-    filter?: CrudFilter<ID, RowType>,
+    filter?: CrudFilter<ID, ROW>,
     sorts?: Array<Sort>,
     relations?: Array<Relation>
   ): Promise<ROW | undefined> {
@@ -154,7 +150,8 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   }
 
   async selectById(id: ID, relations?: Array<Relation>): Promise<ROW | undefined> {
-    return this.selectFirst({ include: { [this.idColumn]: id } }, undefined, relations);
+    const include = { [this.idColumn]: id } as CrudFilterColumns<Partial<ROW>>;
+    return this.selectFirst({ include }, undefined, relations);
   }
 
   //---------------------------------------------------------
@@ -223,7 +220,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   //---------------------------------------------------------
   // extension point
 
-  protected applyFilter(queryBuilder: Knex.QueryBuilder, filter?: CrudFilter<ID, RowType>) {
+  protected applyFilter(queryBuilder: Knex.QueryBuilder, filter?: CrudFilter<ID, ROW>) {
     if (!filter) {
       return;
     }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
CrudFilter에 제너릭 타입을 ROW로 제한할 수 있는 곳들이 RowType으로 되어있다

## 무엇을 어떻게 변경했나요?
CrudFilter<ID, RowType>를 CrudFilter<ID, ROW>로 변경

## 어떻게 테스트 하셨나요?
npm run test
