### PR TITLE
feat: Database 에서 retrieve 된 ROW를 Required<> 처리한다.

### DIFF
--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -38,19 +38,23 @@ export interface CrudOperationsOpts<ID extends IdType = number, ROW extends RowT
 }
 
 export interface SelectOperations<ID extends IdType, ROW extends RowType> {
-  select(filter?: CrudFilter<ID, ROW>, sorts?: Array<Sort>, relations?: Array<Relation>): Promise<Array<ROW>>;
+  select(filter?: CrudFilter<ID, ROW>, sorts?: Array<Sort>, relations?: Array<Relation>): Promise<Array<Required<ROW>>>;
 
   count(filter?: CrudFilter<ID, ROW>): Promise<number>;
 
-  selectFirst(filter?: CrudFilter<ID, ROW>, sorts?: Array<Sort>, relations?: Array<Relation>): Promise<ROW | undefined>;
+  selectFirst(
+    filter?: CrudFilter<ID, ROW>,
+    sorts?: Array<Sort>,
+    relations?: Array<Relation>
+  ): Promise<Required<ROW> | undefined>;
 
   exist(filter?: CrudFilter<ID, ROW>): Promise<boolean>;
 
-  selectById(id: ID, relations?: Array<Relation>): Promise<ROW | undefined>;
+  selectById(id: ID, relations?: Array<Relation>): Promise<Required<ROW> | undefined>;
 }
 
 export interface InsertOperations<ROW extends RowType> {
-  insert(data: ROW | Array<ROW>): Promise<ROW>;
+  insert(data: ROW | Array<ROW>): Promise<Required<ROW>>;
 }
 
 export interface UpdateOperations<ID extends IdType, ROW extends RowType> {
@@ -107,7 +111,11 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   //---------------------------------------------------------
   // SelectOperation
 
-  async select(filter?: CrudFilter<ID, ROW>, sorts?: Array<Sort>, relations?: Array<Relation>): Promise<Array<ROW>> {
+  async select(
+    filter?: CrudFilter<ID, ROW>,
+    sorts?: Array<Sort>,
+    relations?: Array<Relation>
+  ): Promise<Array<Required<ROW>>> {
     const query = this.knexReplica(this.table).modify((queryBuilder) => {
       this.applyFilter(queryBuilder, filter);
       this.applySort(queryBuilder, sorts);
@@ -139,7 +147,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
     filter?: CrudFilter<ID, ROW>,
     sorts?: Array<Sort>,
     relations?: Array<Relation>
-  ): Promise<ROW | undefined> {
+  ): Promise<Required<ROW> | undefined> {
     const rows = await this.select({ ...filter, limit: 1 }, sorts, relations);
     return rows[0];
   }
@@ -149,7 +157,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
     return row !== undefined;
   }
 
-  async selectById(id: ID, relations?: Array<Relation>): Promise<ROW | undefined> {
+  async selectById(id: ID, relations?: Array<Relation>): Promise<Required<ROW> | undefined> {
     const include = { [this.idColumn]: id } as CrudFilterColumns<ROW>;
     return this.selectFirst({ include }, undefined, relations);
   }
@@ -157,7 +165,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
   //---------------------------------------------------------
   // InsertOperation
 
-  async insert(data: ROW | Array<ROW>): Promise<ROW> {
+  async insert(data: ROW | Array<ROW>): Promise<Required<ROW>> {
     // result is varying on dialect
     // mysql: the first one, sqlite3: the last one, ...
     // see http://knexjs.org/#Builder-insert

--- a/src/weaver.ts
+++ b/src/weaver.ts
@@ -26,7 +26,7 @@ export class Weaver<ID extends IdType = number, ROW extends RowType = RowType> {
     this.logger = LoggerFactory.getLogger('fastdao:weaver');
   }
 
-  async weave(rows?: Array<ROW>, relations?: Array<Relation>): Promise<Array<ROW>> {
+  async weave(rows?: Array<Required<ROW>>, relations?: Array<Relation>): Promise<Array<Required<ROW>>> {
     if (!rows || rows.length === 0 || !relations || relations.length === 0) {
       // nothing to weave
       return [];
@@ -64,9 +64,9 @@ export class Weaver<ID extends IdType = number, ROW extends RowType = RowType> {
     return rows;
   }
 
-  async selectRelationByIds(relation: Relation, ids: Array<ID>): Promise<Array<ROW>> {
+  async selectRelationByIds(relation: Relation, ids: Array<ID>): Promise<Array<Required<ROW>>> {
     const missedIds: Array<ID> = [];
-    const hitRows: Array<ROW> = [];
+    const hitRows: Array<Required<ROW>> = [];
     if (this.cache) {
       const cached: Array<string | null> =
         ids && ids.length ? await this.cache.getAll(ids.map((id) => relation.table + ':' + id)) : [];


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

Insert 전의 프로퍼티는 optional 일 수 있으나, Create -> Retrieve 된 데이터의 프로퍼티들은 undefined 일 수 없다.

다시말해
Insert 전의 프로퍼티는 undefined / null / not null 중 하나일 수 있지만, Retrieve 후 의 프로퍼티들은 null / not null 만 가능하다.

## 무엇을 어떻게 변경했나요?

데이터베이스를 거쳐 반환되는 ROW들에 대해 `Required<ROW>` 처리

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

구현측에서 nullable 필드를 ` | null` 로 유니언이 필요할 수 있습니다. 

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
