### PR TITLE
feat: step down weaver cache hit log to trace(10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
-        "@day1co/fastcache": "^3.0.2",
+        "@day1co/fastcache": "^3.0.4",
         "@day1co/fastcase": "^3.0.0",
-        "@day1co/pebbles": "~3.1.15",
+        "@day1co/pebbles": "~3.1.27",
         "ioredis": "^4.28.5",
         "knex": "^1.0.7",
         "mysql2": "^2.3.3"
@@ -657,9 +657,9 @@
       "license": "MIT"
     },
     "node_modules/@day1co/pebbles": {
-      "version": "3.1.22",
-      "resolved": "https://npm.pkg.github.com/download/@day1co/pebbles/3.1.22/f4fab5e9ba359ed135ff292e5251d3048806c9eed6fb6f28fdc559fba2148183",
-      "integrity": "sha512-MOHThm1lCAHD4qf4W7T5Pw2C9h6sRQgFoHRjh0aeGTUIoEndzzat54+e94RTI+Pk9Ss8sr2PLrihgBxllx83LA==",
+      "version": "3.1.27",
+      "resolved": "https://npm.pkg.github.com/download/@day1co/pebbles/3.1.27/809f875ec8abd9ea28e6cc3e56702618bcc3c189e252139ce33b9e2a8cbe2616",
+      "integrity": "sha512-4/Q94Fq8eObKNzYzUP6DPJ0UYtPkzM4z05KhXSHoLrmB4NuK5isMnZ8ZZrHVQgpsvd8ED3ZtDvPhCDHnvrauPA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",
@@ -7158,9 +7158,9 @@
       "integrity": "sha512-D6r8nS60Z9hPkklWJfXqPOqSQniRLI9PY9jmcV98QVEHzUwjeij5Z8+UjJbu9Ub6xviS0mJ2BBuIrh02xA0pyA=="
     },
     "@day1co/pebbles": {
-      "version": "3.1.22",
-      "resolved": "https://npm.pkg.github.com/download/@day1co/pebbles/3.1.22/f4fab5e9ba359ed135ff292e5251d3048806c9eed6fb6f28fdc559fba2148183",
-      "integrity": "sha512-MOHThm1lCAHD4qf4W7T5Pw2C9h6sRQgFoHRjh0aeGTUIoEndzzat54+e94RTI+Pk9Ss8sr2PLrihgBxllx83LA==",
+      "version": "3.1.27",
+      "resolved": "https://npm.pkg.github.com/download/@day1co/pebbles/3.1.27/809f875ec8abd9ea28e6cc3e56702618bcc3c189e252139ce33b9e2a8cbe2616",
+      "integrity": "sha512-4/Q94Fq8eObKNzYzUP6DPJ0UYtPkzM4z05KhXSHoLrmB4NuK5isMnZ8ZZrHVQgpsvd8ED3ZtDvPhCDHnvrauPA==",
       "requires": {
         "axios": "^0.21.4",
         "mustache": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@day1co/fastcache": "^3.0.2",
+    "@day1co/fastcache": "^3.0.4",
     "@day1co/fastcase": "^3.0.0",
-    "@day1co/pebbles": "~3.1.15",
+    "@day1co/pebbles": "~3.1.27",
     "ioredis": "^4.28.5",
     "knex": "^1.0.7",
     "mysql2": "^2.3.3"

--- a/src/weaver.ts
+++ b/src/weaver.ts
@@ -73,7 +73,7 @@ export class Weaver<ID extends IdType = number, ROW extends RowType = RowType> {
       for (let i = 0, count = ids.length; i < count; i += 1) {
         if (cached[i] !== null) {
           hitRows.push(JSON.parse(<string>cached[i]));
-          this.logger.debug(`cache hit: ${relation.table}, id=${ids[i]}`);
+          this.logger.trace(`cache hit: ${relation.table}, id=${ids[i]}`);
           this.cacheStat.hit += 1;
         } else {
           missedIds.push(ids[i]);


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

구글 스택드라이버에 들어가는 로그 중 weaver cache hit 가 너무 많은 비중을 차지하여 로그레벨을 낮춥니다.

- https://cloudlogging.app.goo.gl/aAVM2DurbdMvgagE9
- https://day1c.slack.com/archives/C034K0RKWER/p1657865006781799

## 무엇을 어떻게 변경했나요?

debug (20) -> trace (10)

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

stdout 을 수집하고 있는 구글 로거에 fastdao 의 weaver cache hit 분량이 너무 많아 모니터링에 불편함이 있음
cache hit 는 에러 로그 수집을 목표로 하는 로그 모니터에 적당하지 않음

## 디펜던시 변경이 있나요?

pebbles 최신 버전 3.1.27 이 필요합니다. 

