### PR TITLE
feat: weave에 one-to-many관계도 동작하도록 추가 (제안 및 질문)

### DIFF
--- a/src/relation.ts
+++ b/src/relation.ts
@@ -1,14 +1,16 @@
+export type RelationType = 'ONE_TO_MANY';
 export interface Relation {
   table: string;
   column: string;
   fk: string;
   property: string;
+  type?: RelationType;
 }
 
 const defaultFk = (table: string, fk?: string) => fk || `${table}Id`;
 
-export function relation(table: string, column = 'id', fk?: string, property?: string) {
-  return { table, column, fk: fk || defaultFk(table, fk), property: property || table };
+export function relation(table: string, column = 'id', fk?: string, property?: string, type?: RelationType) {
+  return { table, column, fk: fk || defaultFk(table, fk), property: property || table, type };
 }
 
 // ex. `user` === `user.id` === `userId=user.id` === `userId=user.id@user`

--- a/src/weaver.spec.ts
+++ b/src/weaver.spec.ts
@@ -41,6 +41,27 @@ describe('weaver', () => {
         expect(post.user).toEqual(await knex('user').where({ id: post.userId }).first());
       }
     });
+    it('should weave one-to-many relationships', async () => {
+      const rr = Weaver.create({ knex, cache });
+      const posts = await knex('post').select();
+      const postsWithRels = await rr.weave(posts, [
+        {
+          table: 'postTag',
+          column: 'postId',
+          fk: 'id',
+          property: 'postTag',
+          type: 'ONE_TO_MANY',
+        },
+      ]);
+      for (const post of postsWithRels) {
+        const relationData = await knex('postTag').where({ postId: post.id });
+        if (relationData.length === 0) {
+          expect(post.postTag).toBeUndefined();
+        } else {
+          expect(post.postTag).toMatchObject(relationData);
+        }
+      }
+    });
     it('should weave nothing', async () => {
       const rr = Weaver.create({ knex, cache });
       expect(await rr.weave()).toEqual([]);

--- a/src/weaver.ts
+++ b/src/weaver.ts
@@ -54,8 +54,12 @@ export class Weaver<ID extends IdType = number, ROW extends RowType = RowType> {
           ) {
             const relRow = relationRows[relationRowIndex];
             if (fkValue === relRow[relation.column]) {
-              row[relation.property] = relRow;
-              break;
+              if (relation.type === 'ONE_TO_MANY') {
+                row[relation.property] = row[relation.property] ? [...row[relation.property], relRow] : [relRow];
+              } else {
+                row[relation.property] = relRow;
+                break;
+              }
             }
           }
         }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 새로운 기능

## 무엇을 어떻게 변경했나요?
weave에 relation을 one-to-many로 설정할 경우 관계되는 모든 데이터를 리턴하도록 수정했습니다

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.
fastdao를 쓰다가 relation을 쓰고싶은데 1:n이 지원이 안되서 못썼던 케이스가 종종 있었던것이 생각나 수정해 보았습니다
Q. 첫번째 데이터만 리턴하는것이 성능상 문제로인해 의도된것인지 궁금합니다 :eyes:

## 어떻게 테스트 하셨나요?
스모크 테스트

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
```
 PASS  src/weaver.spec.ts
  weaver
    weave
      ✓ should weave (58 ms)
      ✓ should weave one-to-many relationships (33 ms)
      ✓ should weave nothing (19 ms)
      ✓ should throw (25 ms)
```