### PR TITLE
remove ioredis type definition package in dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@day1co/prettier-config": "^1.0.0",
         "@day1co/tsconfig": "^1.2.1",
         "@tsconfig/node-lts": "^18.12.1",
-        "@types/ioredis": "^5.0.0",
         "@types/ioredis-mock": "^8.2.2",
         "@types/jest": "^29.2.5",
         "@types/node": "^18.16.19",
@@ -1688,16 +1687,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ioredis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
-      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
-      "deprecated": "This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "ioredis": "*"
       }
     },
     "node_modules/@types/ioredis-mock": {
@@ -9964,15 +9953,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/ioredis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
-      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
-      "dev": true,
-      "requires": {
-        "ioredis": "*"
       }
     },
     "@types/ioredis-mock": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@day1co/prettier-config": "^1.0.0",
     "@day1co/tsconfig": "^1.2.1",
     "@tsconfig/node-lts": "^18.12.1",
-    "@types/ioredis": "^5.0.0",
     "@types/ioredis-mock": "^8.2.2",
     "@types/jest": "^29.2.5",
     "@types/node": "^18.16.19",


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 메인터넌스

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

최근 ioredis 는 패키지의 type 정보를 직접 해당 패키지 안에서 제공하고 있다.
반면 그동안 사용하던 @types/ioredis 때문에 타입 정보가 일치하지 않는 문제로 빌드 실패가 발생하는 경우가 있어 

redstone 5.1 대응 버전에는 이 타입 선언을 제거하도록 한다.

## 무엇을 어떻게 변경했나요?

@types/ioredis 패키지 제거

## 어떻게 테스트 하셨나요?

본 패키지도 next 태그를 달고 배포되어 점검/사용될 예정입니다.
