### PR TITLE
fix: mysql 에서 whereLike 실행 시 발생하는 COLLATION 'utf8_bin' is not valid f…

### DIFF
--- a/src/crud-operations.spec.ts
+++ b/src/crud-operations.spec.ts
@@ -94,61 +94,65 @@ describe('crud-operations', () => {
     it('should select with full contain filter', async () => {
       const postRows = await postCrud.select({ fullContain: { content: 'f1' } });
       expect(postRows).toHaveLength(3);
-      expect(postRows).toMatchObject(await knex('post').whereLike('content', `%f1%`));
+      expect(postRows).toMatchObject(await knex('post').where('content', 'like', `%f1%`));
       expect(postRows).toMatchObject(await knex('post').whereIn('id', [1, 4, 7]).select());
 
       const forumRows = await forumCrud.select({ fullContain: { description: 'f1' } });
       expect(forumRows).toHaveLength(1);
-      expect(forumRows).toMatchObject(await knex('forum').whereLike('description', '%f1%'));
+      expect(forumRows).toMatchObject(await knex('forum').where('description', 'like', '%f1%'));
       expect(forumRows).toMatchObject(await knex('forum').where({ id: 1 }));
     });
     it('should select with left side contain filter', async () => {
       const rows = await postCrud.select({ leftContain: { content: 'u1' } });
       expect(rows).toHaveLength(3);
-      expect(rows).toMatchObject(await knex('post').whereLike('content', `%u1`));
+      expect(rows).toMatchObject(await knex('post').where('content', 'like', `%u1`));
       expect(rows).toMatchObject(await knex('post').whereIn('id', [1, 2, 3]).select());
 
       const forumRows = await forumCrud.select({ leftContain: { description: 'u1' } });
       expect(forumRows).toHaveLength(1);
-      expect(forumRows).toMatchObject(await knex('forum').whereLike('description', '%u1'));
+      expect(forumRows).toMatchObject(await knex('forum').where('description', 'like', '%u1'));
       expect(forumRows).toMatchObject(await knex('forum').where({ id: 1 }));
     });
     it('should select with right side contain filter', async () => {
       const rows = await postCrud.select({ rightContain: { content: 'p1' } });
       expect(rows).toHaveLength(2);
-      expect(rows).toMatchObject(await knex('post').whereLike('content', `p1%`));
+      expect(rows).toMatchObject(await knex('post').where('content', 'like', `p1%`));
       expect(rows).toMatchObject(await knex('post').whereIn('id', [1, 10]).select());
 
       const forumRows = await forumCrud.select({ rightContain: { description: 'f3' } });
       expect(forumRows).toHaveLength(1);
-      expect(forumRows).toMatchObject(await knex('forum').whereLike('description', 'f3%'));
+      expect(forumRows).toMatchObject(await knex('forum').where('description', 'like', 'f3%'));
       expect(forumRows).toMatchObject(await knex('forum').where({ id: 3 }));
     });
     it('should select with contain filter', async () => {
       const rows = await postCrud.select({ contain: { content: 'p1' } });
       expect(rows).toHaveLength(2);
-      expect(rows).toMatchObject(await knex('post').whereLike('content', `p1%`));
+      expect(rows).toMatchObject(await knex('post').where('content', 'like', `p1%`));
       expect(rows).toMatchObject(await knex('post').whereIn('id', [1, 10]).select());
 
       const forumRows = await forumCrud.select({ contain: { description: 'f3' } });
       expect(forumRows).toHaveLength(1);
-      expect(forumRows).toMatchObject(await knex('forum').whereLike('description', 'f3%'));
+      expect(forumRows).toMatchObject(await knex('forum').where('description', 'like', 'f3%'));
       expect(forumRows).toMatchObject(await knex('forum').where({ id: 3 }));
     });
 
     it('bad use case: should select with contain and right side contain filter', async () => {
       const postRows = await postCrud.select({ rightContain: { content: 'p1' }, contain: { content: 'p1' } });
       expect(postRows).toHaveLength(2);
-      expect(postRows).toMatchObject(await knex('post').whereLike('content', `p1%`));
+      expect(postRows).toMatchObject(await knex('post').where('content', 'like', `p1%`));
       expect(postRows).toMatchObject(await knex('post').whereIn('id', [1, 10]).select());
 
       const postRows2 = await postCrud.select({ rightContain: { content: 'p2' }, contain: { content: 'p1' } });
       expect(postRows2).toHaveLength(0);
-      expect(postRows2).toMatchObject(await knex('post').whereLike('content', `p2%`).whereLike('content', `p1%`));
+      expect(postRows2).toMatchObject(
+        await knex('post').where('content', 'like', `p2%`).where('content', 'like', `p1%`)
+      );
 
       const forumRows = await forumCrud.select({ rightContain: { title: 'f3' }, contain: { description: 'f3' } });
       expect(forumRows).toHaveLength(1);
-      expect(forumRows).toMatchObject(await knex('forum').whereLike('description', 'f3%').whereLike('title', 'f3%'));
+      expect(forumRows).toMatchObject(
+        await knex('forum').where('description', 'like', 'f3%').where('title', 'like', 'f3%')
+      );
       expect(forumRows).toMatchObject(await knex('forum').where({ id: 3 }));
     });
   });

--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -266,21 +266,21 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
     if (fullContain) {
       for (const [key, value] of Object.entries(fullContain)) {
         if (canExactMatch(value)) {
-          queryBuilder.whereLike(this.columnName(key), `%${value}%`);
+          queryBuilder.where(this.columnName(key), 'like', `%${value}%`);
         }
       }
     }
     if (leftContain) {
       for (const [key, value] of Object.entries(leftContain)) {
         if (canExactMatch(value)) {
-          queryBuilder.whereLike(this.columnName(key), `%${value}`);
+          queryBuilder.where(this.columnName(key), 'like', `%${value}`);
         }
       }
     }
     if (rightContain) {
       for (const [key, value] of Object.entries(rightContain)) {
         if (canExactMatch(value)) {
-          queryBuilder.whereLike(this.columnName(key), `${value}%`);
+          queryBuilder.where(this.columnName(key), 'like', `${value}%`);
         }
       }
     }
@@ -288,7 +288,7 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
     if (contain) {
       for (const [key, value] of Object.entries(contain)) {
         if (canExactMatch(value)) {
-          queryBuilder.whereLike(this.columnName(key), `${value}%`);
+          queryBuilder.where(this.columnName(key), 'like', `${value}%`);
         }
       }
     }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
* 문제: mysql 에서 whereLike 검색 시 쿼리 실행 오류가 발생 (COLLATION 'utf8_bin' is not valid for CHARACTER SET 'utf8mb4')
* 원인: knex 에서 whereLike 사용 시 하드코딩으로 character set 을 넣고 있음(https://github.com/knex/knex/blob/master/lib/dialects/mysql/query/mysql-querycompiler.js#L185)

## 무엇을 어떻게 변경했나요?
* fullContext 등 like 검색을 사용하는 곳은 knex whereLike -> where 로 변경합니다.

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
