### PR TITLE
add condition to handle filter with empty array and valid value

### DIFF
--- a/src/crud-operations.spec.ts
+++ b/src/crud-operations.spec.ts
@@ -62,6 +62,11 @@ describe('crud-operations', () => {
       expect(rows).toMatchObject(await knex('post').whereIn('id', []).select());
       expect(rows).toHaveLength(0);
     });
+    it('should select with include filter by empty array and valid value', async () => {
+      const rows = await postCrud.select({ include: { id: [], forumId: '1' } });
+      expect(rows).toStrictEqual(await knex('post').where('forum_id', 1).select());
+      expect(rows).toHaveLength(3);
+    });
     it('should select with include/exclude null filter', async () => {
       const rows1 = await postCrud.select({ include: { id: [9, 10], linked_post_id: null } });
       expect(rows1).toMatchObject(await knex('post').whereIn('id', [9]).select());

--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -328,14 +328,13 @@ export class CrudOperations<ID extends IdType = number, ROW extends RowType = Ro
 
   protected isValidFilter(filter?: CrudFilter<ID, ROW>) {
     // 빈배열 검색일 경우 1 = 0 같은 무의미한 조회 방지 필터
-    if (filter?.include) {
-      for (const value of Object.values(filter.include)) {
-        if (Array.isArray(value) && value.length === 0) {
-          return false;
-        }
+    if (!filter?.include) return true;
+
+    for (const value of Object.values(filter.include)) {
+      if ((Array.isArray(value) && value.length !== 0) || canExactMatch(value)) {
+        return true;
       }
     }
-
-    return true;
+    return false;
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ export const canExactMatchIn = (value: unknown): value is Array<Date | number | 
   // XXX: knex 1.0.x  이후 empty array 에 대해 where in () 대신 where 1 = 0 을 생성하여
   //  항상 where 필터가 동작하도록 변경
   // https://github.com/knex/knex/issues/2897
-  return Array.isArray(value) && value.every((it) => canExactMatch(it));
+  return Array.isArray(value) && value.length !== 0 && value.every((it) => canExactMatch(it));
 };
 
 export const isNull = (value: unknown): value is null => {


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 워크플로우 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

filter.include에 [] 와 값이 존재해도 []를 리턴한다
ex ) filter.include = { id : [], site : "COLOSO" } 인 경우 select * from table where site = "COLOSO" 가 아닌 []를 리턴
기존에는 이런경우가 없었지만 selectAll을 select로 정리하는 과정에서 파라미터의 미스매칭을 잡으면서 문제가 생김.

테스트코드도 toMatchObject는 [...].toMatchObject([]) 는 참으로 나와서 toStrictEqual 을 이용함. 다른부분도 바꾸면 좋을듯

## 무엇을 어떻게 변경했나요?

## 코드 변경을 이해하기 위한 배경지식이 필요하다면 설명 해주세요.

## 디펜던시 변경이 있나요?

## 어떻게 테스트 하셨나요?

테스트 코드

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
