### PR TITLE
feat: CrudFilter에서 projection 부분 deprecated 제거

### DIFF
--- a/src/crud-operations.ts
+++ b/src/crud-operations.ts
@@ -30,7 +30,6 @@ export interface CrudFilter<ID extends IdType = number, ROW extends RowType = Ro
   until?: Date | string;
   offset?: number;
   limit?: number;
-  /** @deprecated */
   projection?: Array<string>;
 }
 


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [X] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
데이터베이스 조회 시, 필요한 컬럼만 가져올 수 있는 projection을 살려냅니다.
toView에서 반복문을 통해 처리해주는 것 보다 필요한 컬럼만 가져오는 것이 나을 수 있을 때(page 테이블 등...)가 있을 것이라 생각되었습니다.
개념상 별도로 분리해주는게 맞다는 생각이나, 사이드 이펙트가 클 것으로 보여 deprecated를 제거해주는 방향으로 진행하였습니다.
